### PR TITLE
Remove scanf() call from dhrystone program

### DIFF
--- a/dhry_1.c
+++ b/dhry_1.c
@@ -122,13 +122,17 @@ main ()
     printf ("Program compiled without 'register' attribute\n");
     printf ("\n");
   }
+#ifdef DHRY_ITERS
+  Number_Of_Runs = DHRY_ITERS;
+#else
   printf ("Please give the number of runs through the benchmark: ");
   {
     int n;
     scanf ("%d", &n);
-    Number_Of_Runs = DHRY_ITERS;
+    Number_Of_Runs = n;
   }
   printf ("\n");
+#endif
 
   printf ("Execution starts, %d runs through Dhrystone\n", Number_Of_Runs);
 


### PR DESCRIPTION
The dhrystone program was modified to used the DHRY_ITERS compile time macro to specify the number of iterations, but a call to scanf was left in, even though the value returned is never used. 

This does not cause a problem if the _read() function is a nop, but on systems that semihost the _read() function (such as the OVPsim simulator) this causes an issue.

This patch fixes the problem by checking if the DHRY_ITERS macro has been defined, and if so it uses it, otherwise it prompts the user to specify the number of runs, and uses the value returned.